### PR TITLE
Option to generate code in separate files

### DIFF
--- a/Xsd2Code.ConfigurationForm/FormOption.cs
+++ b/Xsd2Code.ConfigurationForm/FormOption.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Windows.Forms;
 using Xsd2Code.Library;
-using System.Diagnostics;
 
 namespace Xsd2Code.ConfigurationForm
 {
@@ -29,9 +29,9 @@ namespace Xsd2Code.ConfigurationForm
         {
             get
             {
-                return chkOpenAfterGenerate.Checked;   
+                return chkOpenAfterGenerate.Checked;
             }
-        }      
+        }
 
         #endregion
 
@@ -49,21 +49,22 @@ namespace Xsd2Code.ConfigurationForm
 
         #region Method
 
-      /// <summary>
-      /// Analyse file to find generation option.
-      /// </summary>
-      /// <param name="xsdFilePath">path of the xsd-file, which is the central input for the code generation.</param>
-      /// <param name="languageIdentifier">The language identifier (uuid), identifies VC or C#.</param>
-      /// <param name="defaultNamespace">The default namespace for generated classes.</param>
-      /// <param name="framework">.NET Framework version to be used for generated code</param>
-      public void Init(string xsdFilePath, string languageIdentifier, string defaultNamespace, TargetFramework framework)
-        {            
+        /// <summary>
+        /// Analyse file to find generation option.
+        /// </summary>
+        /// <param name="xsdFilePath">path of the xsd-file, which is the central input for the code generation.</param>
+        /// <param name="languageIdentifier">The language identifier (uuid), identifies VC or C#.</param>
+        /// <param name="defaultNamespace">The default namespace for generated classes.</param>
+        /// <param name="framework">.NET Framework version to be used for generated code</param>
+        /// <param name="previousOutputFile">A previous outputfile for the xsd-file to find the parameters from</param>
+        public void Init(string xsdFilePath, string languageIdentifier, string defaultNamespace, TargetFramework framework, string previousOutputFile = null)
+        {
             string outputFile;
-            this.generatorParams = GeneratorParams.LoadFromFile(xsdFilePath, out outputFile);
+            this.generatorParams = GeneratorParams.LoadFromFile(xsdFilePath, out outputFile, previousOutputFile);
 
             if (this.generatorParams == null)
             {
-                this.generatorParams = new GeneratorParams();
+                this.generatorParams = new GeneratorParams(xsdFilePath);
                 switch (languageIdentifier)
                 {
                     case "{B5E9BD33-6D3E-4B5D-925E-8A43B79820B4}":
@@ -100,7 +101,7 @@ namespace Xsd2Code.ConfigurationForm
         private void btnGenerate_Click(object sender, EventArgs e)
         {
             var result = this.generatorParams.Validate();
-            if(!result.Success)
+            if (!result.Success)
             {
                 MessageBox.Show(result.Messages.ToString());
                 return;
@@ -118,7 +119,7 @@ namespace Xsd2Code.ConfigurationForm
         /// <param name="sender">Object sender</param>
         /// <param name="e">EventArgs param</param>
         private void FormOption_KeyPress(object sender, KeyPressEventArgs e)
-        {            
+        {
             int ascii = Convert.ToInt16(e.KeyChar);
             if (ascii == 27) this.Close();
         }
@@ -130,5 +131,5 @@ namespace Xsd2Code.ConfigurationForm
 
 
 
-   }
+    }
 }

--- a/Xsd2Code.ConfigurationForm/Xsd2Code.ConfigurationForm.csproj
+++ b/Xsd2Code.ConfigurationForm/Xsd2Code.ConfigurationForm.csproj
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>14.0</OldToolsVersion>
-    <UpgradeBackupLocation />
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>

--- a/Xsd2Code.Console/EntryPoint.cs
+++ b/Xsd2Code.Console/EntryPoint.cs
@@ -23,7 +23,7 @@ namespace Xsd2Code
     internal class EntryPoint
     {
         [STAThread]
-        static private void Main(string[] args)
+        private static void Main(string[] args)
         {
             // Display hekp when no parameters have been specified
             if (args.Length < 1)
@@ -120,6 +120,14 @@ namespace Xsd2Code
                             Console.WriteLine("Warning: /cb /codebase is obsolete please use /pl[atform] <Platform> - Generated code target platform (Net20|Net30|Net35|Silverlight20). Default: Net20");
                             generatorParams.TargetFramework = Utility.ToEnum<TargetFramework>(args[i + 1]);
                             i++;
+                        }
+                        break;
+
+                    case "/gsf":
+                    case "/generateseparatefiles":
+                        if (i < args.Length - 1)
+                        {
+                            generatorParams.GenerateSeparateFiles = true;
                         }
                         break;
 
@@ -326,7 +334,7 @@ namespace Xsd2Code
                     case "/ee+":
                         generatorParams.Serialization.EnableEncoding = true;
                         break;
-                    
+
                     case "/ee-":
                         generatorParams.Serialization.EnableEncoding = false;
                         break;
@@ -382,7 +390,7 @@ namespace Xsd2Code
             Console.WriteLine();
         }
 
-        static private void DisplayApplicationInfo()
+        private static void DisplayApplicationInfo()
         {
             var currentAssembly = Assembly.GetExecutingAssembly();
             var currentAssemblyName = currentAssembly.GetName();
@@ -396,7 +404,7 @@ namespace Xsd2Code
         /// <summary>
         /// Display contents of the help file ~/Resources/Help.txt
         /// </summary>
-        static private void DisplayHelp()
+        private static void DisplayHelp()
         {
             Console.WriteLine();
             Console.WriteLine(Resources.Help);
@@ -406,7 +414,7 @@ namespace Xsd2Code
         /// <summary>
         /// Display contents of the help file ~/Resources/Help.txt
         /// </summary>
-        static private void DisplayLicense()
+        private static void DisplayLicense()
         {
             Console.WriteLine();
             Console.WriteLine(Resources.License);

--- a/Xsd2Code.Console/Resources/Help.txt
+++ b/Xsd2Code.Console/Resources/Help.txt
@@ -17,6 +17,7 @@ Options:
     /n[s] <Namespace>                   - Generated code CLR namespace. Default: file name without extension
     /l[anguage] <Language>              - Generated code language (CS|VB|CPP). Default: CS
     /pl[atform] <Platform>              - Generated code target platform (Net20|Net30|Net35|Silverlight20). Default: Net20
+	/gsf[generateseparatefiles]         - Generate code in separate files (one for each type)
     /c[ollection] <Collection Base>     - Collection base (Array|BindingList|List|ObservableCollection|DefinedType). Default: List
     /cu[customusings] <Custom Usings>   - Comma-separated of custom usings definition (E.g "Xsd2Code.Library,System.Xml.Linq")
     /sm <Serialize>                     - Serialize method name. Default: Serialize

--- a/Xsd2Code.Console/Resources/Readme.txt
+++ b/Xsd2Code.Console/Resources/Readme.txt
@@ -19,6 +19,7 @@ Options:
     /n[s] <Namespace>                   - Generated code CLR namespace. Default: file name without extension
     /l[anguage] <Language>              - Generated code language (CS|VB|CPP). Default: CS
     /pl[atform] <Platform>              - Generated code target platform (Net20|Net30|Net35|Silverlight20). Default: Net20
+	/gsf[generateseparatefiles]         - Generate code in separate files (one for each type)
     /c[ollection] <Collection Base>     - Collection base (Array|BindingList|List|ObservableCollection|DefinedType). Default: List
     /cu[ustomusings] <Custom Usings>    - Comma-separated of custom usings definition (E.g "Xsd2Code.Library,System.Xml.Linq")
     /sm <Serialize>                     - Serialize method name. Default: Serialize

--- a/Xsd2Code.Library/Extensions/CodeExtension.cs
+++ b/Xsd2Code.Library/Extensions/CodeExtension.cs
@@ -22,12 +22,11 @@
 // </remarks>
 // --------------------------------------------------------------------------------------------------------------------
 
-using System.Collections.ObjectModel;
 using System.Text;
-using Xsd2Code.Library.Properties;
 
 namespace Xsd2Code.Library.Extensions
 {
+    using Helpers;
     using System;
     using System.CodeDom;
     using System.Collections;
@@ -39,7 +38,6 @@ namespace Xsd2Code.Library.Extensions
     using System.Xml;
     using System.Xml.Schema;
     using System.Xml.Serialization;
-    using Helpers;
 
     public class ObjectList : List<object> { }
 
@@ -237,11 +235,11 @@ namespace Xsd2Code.Library.Extensions
             // }
             // ----------------------------------------------------------------------
             var cloneMethod = new CodeMemberMethod
-                                  {
-                                      Attributes = MemberAttributes.Public,
-                                      Name = "Clone",
-                                      ReturnType = new CodeTypeReference(typeName)
-                                  };
+            {
+                Attributes = MemberAttributes.Public,
+                Name = "Clone",
+                ReturnType = new CodeTypeReference(typeName)
+            };
 
             CodeDomHelper.CreateSummaryComment(
                 cloneMethod.Comments,
@@ -268,11 +266,11 @@ namespace Xsd2Code.Library.Extensions
             // }
             // ----------------------------------------------------------------------
             var cloneMethod = new CodeMemberMethod
-                                  {
-                                      Attributes = MemberAttributes.Public,
-                                      Name = string.Format("ShouldSerialize{0}", propertyName),
-                                      ReturnType = new CodeTypeReference(typeof(bool))
-                                  };
+            {
+                Attributes = MemberAttributes.Public,
+                Name = string.Format("ShouldSerialize{0}", propertyName),
+                ReturnType = new CodeTypeReference(typeof(bool))
+            };
 
             CodeDomHelper.CreateSummaryComment(
                 cloneMethod.Comments,
@@ -478,21 +476,21 @@ namespace Xsd2Code.Library.Extensions
         private void CreateChangeTrackerProperty(CodeTypeDeclaration type)
         {
             var changeTrackerPropertyPrivate = new CodeMemberField()
-                                                   {
-                                                       Attributes = MemberAttributes.Final | MemberAttributes.Private,
-                                                       Name = "changeTrackerField",
-                                                       Type = new CodeTypeReference("ObjectChangeTracker")
-                                                   };
+            {
+                Attributes = MemberAttributes.Final | MemberAttributes.Private,
+                Name = "changeTrackerField",
+                Type = new CodeTypeReference("ObjectChangeTracker")
+            };
 
             type.Members.Add(changeTrackerPropertyPrivate);
 
             var changeTrackerProperty = new CodeMemberProperty()
-                                            {
-                                                Attributes = MemberAttributes.Final | MemberAttributes.Public,
-                                                Name = "ChangeTracker",
-                                                HasGet = true,
-                                                Type = new CodeTypeReference("ObjectChangeTracker")
-                                            };
+            {
+                Attributes = MemberAttributes.Final | MemberAttributes.Public,
+                Name = "ChangeTracker",
+                HasGet = true,
+                Type = new CodeTypeReference("ObjectChangeTracker")
+            };
             changeTrackerProperty.CustomAttributes.Add(new CodeAttributeDeclaration("XmlIgnore"));
             changeTrackerProperty.GetStatements.Add(this.CreateInstanceIfNotNull(changeTrackerPropertyPrivate.Name, changeTrackerProperty.Type, new CodeSnippetExpression("this")));
             changeTrackerProperty.GetStatements.Add(new CodeMethodReturnStatement(new CodeSnippetExpression("changeTrackerField")));
@@ -510,12 +508,12 @@ namespace Xsd2Code.Library.Extensions
             // -------------------------------------------------------------------------------
             var propertyChangedEvent =
                 new CodeMemberEvent
-                    {
-                        Attributes = MemberAttributes.Final | MemberAttributes.Public,
-                        Name = "PropertyChanged",
-                        Type =
+                {
+                    Attributes = MemberAttributes.Final | MemberAttributes.Public,
+                    Name = "PropertyChanged",
+                    Type =
                             new CodeTypeReference(typeof(PropertyChangedEventHandler))
-                    };
+                };
             propertyChangedEvent.ImplementationTypes.Add(new CodeTypeReference("INotifyPropertyChanged"));
             type.Members.Add(propertyChangedEvent);
 
@@ -617,10 +615,10 @@ namespace Xsd2Code.Library.Extensions
         protected virtual CodeMemberMethod CreateSerializeMethod(CodeTypeDeclaration type)
         {
             var serializeMethod = new CodeMemberMethod
-                                      {
-                                          Attributes = MemberAttributes.Public,
-                                          Name = GeneratorContext.GeneratorParams.Serialization.SerializeMethodName
-                                      };
+            {
+                Attributes = MemberAttributes.Public,
+                Name = GeneratorContext.GeneratorParams.Serialization.SerializeMethodName
+            };
 
             var tryStatmanentsCol = new CodeStatementCollection();
             var finallyStatmanentsCol = new CodeStatementCollection();
@@ -813,8 +811,8 @@ namespace Xsd2Code.Library.Extensions
                                                             new CodeExpression[]
                                                             {
                                                                 CodeDomHelper.GetInvokeMethod(
-                                                                "System.Xml.XmlReader", 
-                                                                "Create", 
+                                                                "System.Xml.XmlReader",
+                                                                "Create",
                                                                 new CodeExpression[] { new CodeVariableReferenceExpression("stringReader") })
                                                             });
 
@@ -846,10 +844,10 @@ namespace Xsd2Code.Library.Extensions
             // public static bool Deserialize(string xml, out T obj, out System.Exception exception)
             // -------------------------------------------------------------------------------------
             var deserializeMethod = new CodeMemberMethod
-                                        {
-                                            Attributes = MemberAttributes.Public | MemberAttributes.Static,
-                                            Name = GeneratorContext.GeneratorParams.Serialization.DeserializeMethodName
-                                        };
+            {
+                Attributes = MemberAttributes.Public | MemberAttributes.Static,
+                Name = GeneratorContext.GeneratorParams.Serialization.DeserializeMethodName
+            };
 
             deserializeMethod.Parameters.Add(new CodeParameterDeclarationExpression(typeof(string), "xml"));
 
@@ -1088,10 +1086,10 @@ namespace Xsd2Code.Library.Extensions
         {
             var saveToFileMethodList = new List<CodeMemberMethod>();
             var saveToFileMethod = new CodeMemberMethod
-                                       {
-                                           Attributes = MemberAttributes.Public,
-                                           Name = GeneratorContext.GeneratorParams.Serialization.SaveToFileMethodName
-                                       };
+            {
+                Attributes = MemberAttributes.Public,
+                Name = GeneratorContext.GeneratorParams.Serialization.SaveToFileMethodName
+            };
 
             saveToFileMethod.Parameters.Add(new CodeParameterDeclarationExpression(typeof(string), "fileName"));
 
@@ -1102,9 +1100,9 @@ namespace Xsd2Code.Library.Extensions
 
             var paramException = new CodeParameterDeclarationExpression(
                 typeof(Exception), "exception")
-                                     {
-                                         Direction = FieldDirection.Out
-                                     };
+            {
+                Direction = FieldDirection.Out
+            };
 
             saveToFileMethod.Parameters.Add(paramException);
 
@@ -1172,10 +1170,10 @@ namespace Xsd2Code.Library.Extensions
             if (GeneratorContext.GeneratorParams.Serialization.EnableEncoding)
             {
                 saveToFileMethod = new CodeMemberMethod
-                                       {
-                                           Attributes = MemberAttributes.Public,
-                                           Name = GeneratorContext.GeneratorParams.Serialization.SaveToFileMethodName
-                                       };
+                {
+                    Attributes = MemberAttributes.Public,
+                    Name = GeneratorContext.GeneratorParams.Serialization.SaveToFileMethodName
+                };
 
                 CodeExpression[] encodeingArgs;
                 encodeingArgs = new CodeExpression[]
@@ -1205,10 +1203,10 @@ namespace Xsd2Code.Library.Extensions
             if (GeneratorContext.GeneratorParams.Serialization.EnableEncoding)
             {
                 saveToFileMethod = new CodeMemberMethod
-                                       {
-                                           Attributes = MemberAttributes.Public,
-                                           Name = GeneratorContext.GeneratorParams.Serialization.SaveToFileMethodName
-                                       };
+                {
+                    Attributes = MemberAttributes.Public,
+                    Name = GeneratorContext.GeneratorParams.Serialization.SaveToFileMethodName
+                };
 
                 var encodeingArgs = new CodeExpression[]
                                         {
@@ -1349,10 +1347,10 @@ namespace Xsd2Code.Library.Extensions
             var teeType = new CodeTypeReference(typeName);
             var loadFromFileMethodList = new List<CodeMemberMethod>();
             var loadFromFileMethod = new CodeMemberMethod
-                                         {
-                                             Attributes = MemberAttributes.Public | MemberAttributes.Static,
-                                             Name = GeneratorContext.GeneratorParams.Serialization.LoadFromFileMethodName
-                                         };
+            {
+                Attributes = MemberAttributes.Public | MemberAttributes.Static,
+                Name = GeneratorContext.GeneratorParams.Serialization.LoadFromFileMethodName
+            };
 
             loadFromFileMethod.Parameters.Add(new CodeParameterDeclarationExpression(typeof(string), "fileName"));
 
@@ -1440,11 +1438,11 @@ namespace Xsd2Code.Library.Extensions
             if (GeneratorContext.GeneratorParams.Serialization.EnableEncoding)
             {
                 loadFromFileMethod = new CodeMemberMethod
-                                         {
-                                             Attributes = MemberAttributes.Public | MemberAttributes.Static,
-                                             Name =
+                {
+                    Attributes = MemberAttributes.Public | MemberAttributes.Static,
+                    Name =
                                                  GeneratorContext.GeneratorParams.Serialization.LoadFromFileMethodName
-                                         };
+                };
 
                 loadFromFileMethod.Parameters.Add(new CodeParameterDeclarationExpression(typeof(string), "fileName"));
 
@@ -1536,7 +1534,7 @@ namespace Xsd2Code.Library.Extensions
             if (GeneratorContext.GeneratorParams.CustomUsings != null)
             {
                 foreach (var item in GeneratorContext.GeneratorParams.CustomUsings)
-                { 
+                {
                     code.Imports.Add(new CodeNamespaceImport(item.NameSpace));
                 }
             }
@@ -1705,9 +1703,9 @@ namespace Xsd2Code.Library.Extensions
                         typeof(EditorBrowsableAttribute).Name.Replace("Attribute", string.Empty));
 
                     var argument = new CodeAttributeArgument
-                                       {
-                                           Value = CodeDomHelper.GetEnum(typeof(EditorBrowsableState).Name, "Never")
-                                       };
+                    {
+                        Value = CodeDomHelper.GetEnum(typeof(EditorBrowsableState).Name, "Never")
+                    };
 
                     field.CustomAttributes.Add(new CodeAttributeDeclaration(attributeType, new[] { argument }));
                 }
@@ -1730,10 +1728,10 @@ namespace Xsd2Code.Library.Extensions
             // ---------------------------------------
             if (GeneratorContext.GeneratorParams.EnableInitializeFields && GeneratorContext.GeneratorParams.CollectionObjectType != CollectionType.Array)
             {
-                bool found;
-                CodeTypeDeclaration declaration = this.FindTypeInNamespace(field.Type.BaseType, ns, out found);
-                XmlSchemaElement fieldXmlElement = FindByName< XmlSchemaElement>(xmlType, field.Name, GetFieldNameFromElementName);
-                if ((fieldXmlElement == null || !fieldXmlElement.IsNillable) && 
+                bool finded;
+                CodeTypeDeclaration declaration = this.FindTypeInNamespace(field.Type.BaseType, ns, out finded);
+                XmlSchemaElement fieldXmlElement = FindByName<XmlSchemaElement>(xmlType, GetFieldNameFromElementName(field.Name));
+                if ((fieldXmlElement == null || !fieldXmlElement.IsNillable) &&
                     (thisIsCollectionType ||
                     (((declaration != null) && declaration.IsClass)
                      && ((declaration.TypeAttributes & TypeAttributes.Abstract) != TypeAttributes.Abstract))))
@@ -2296,13 +2294,13 @@ namespace Xsd2Code.Library.Extensions
 
             // private static System.Xml.Serialization.XmlSerializer Serializer { get {...} }
             var serializerProperty = new CodeMemberProperty
-                                         {
-                                             Type = new CodeTypeReference(typeof(XmlSerializer)),
-                                             Name = "Serializer",
-                                             HasSet = false,
-                                             HasGet = true,
-                                             Attributes = MemberAttributes.Static | MemberAttributes.Private
-                                         };
+            {
+                Type = new CodeTypeReference(typeof(XmlSerializer)),
+                Name = "Serializer",
+                HasSet = false,
+                HasGet = true,
+                Attributes = MemberAttributes.Static | MemberAttributes.Private
+            };
 
             var statments = new CodeStatementCollection();
 
@@ -2335,11 +2333,11 @@ namespace Xsd2Code.Library.Extensions
         private CodeTypeDeclaration GenerateBaseClass()
         {
             var baseClass = new CodeTypeDeclaration(GeneratorContext.GeneratorParams.GenericBaseClass.BaseClassName)
-                                {
-                                    IsClass = true,
-                                    IsPartial = true,
-                                    TypeAttributes = TypeAttributes.Public
-                                };
+            {
+                IsClass = true,
+                IsPartial = true,
+                TypeAttributes = TypeAttributes.Public
+            };
 
             baseClass.StartDirectives.Add(new CodeRegionDirective(CodeRegionMode.Start, "Base entity class"));
             baseClass.EndDirectives.Add(new CodeRegionDirective(CodeRegionMode.End, "Base entity class"));

--- a/Xsd2Code.Library/Generator.cs
+++ b/Xsd2Code.Library/Generator.cs
@@ -90,7 +90,6 @@ namespace Xsd2Code.Library
             var ns = new CodeNamespace();
 
             XmlReader reader = null;
-            var schemaSet = new XmlSchemaSet();
             try
             {
 
@@ -107,8 +106,10 @@ namespace Xsd2Code.Library
 
                 reader = XmlReader.Create(generatorParams.InputFilePath);
                 xsd = XmlSchema.Read(reader, new ValidationEventHandler(Validate));
-                schemaSet.ValidationEventHandler += new ValidationEventHandler(Validate);
 
+
+                var schemaSet = new XmlSchemaSet();
+                schemaSet.ValidationEventHandler += new ValidationEventHandler(Validate);
 
                 schemaSet.XmlResolver = new XmlUrlResolver();
                 schemaSet.Add(xsd);
@@ -175,7 +176,6 @@ namespace Xsd2Code.Library
                 Console.Write("WARNING: " + e.Message);
             if (e.Severity == XmlSeverityType.Error)
                 throw new Exception("Schema validation failed:\n" + e.Message);
-
         }
     }
 }

--- a/Xsd2Code.Library/GeneratorContext.cs
+++ b/Xsd2Code.Library/GeneratorContext.cs
@@ -184,6 +184,11 @@
         /// </summary>
         public const string ENABLEINITIALIZEFIELDSTAG = "EnableInitializeFields";
 
+        /// <summary>
+        /// Tag for enable/disable generation of separate files
+        /// </summary>
+        public const string GENERATESEPARATEFILES = "GenerateSeparateFiles";
+
         #region Fields
 
         /// <summary>

--- a/Xsd2Code.Library/GeneratorContext.cs
+++ b/Xsd2Code.Library/GeneratorContext.cs
@@ -189,6 +189,11 @@
         /// </summary>
         public const string GENERATESEPARATEFILES = "GenerateSeparateFiles";
 
+        /// <summary>
+        /// Tag for the base file name used for the output file(s)
+        /// </summary>
+        public const string OUTPUTFILEPATH = "OutputFilePath";
+
         #region Fields
 
         /// <summary>

--- a/Xsd2Code.Library/GeneratorFactory.cs
+++ b/Xsd2Code.Library/GeneratorFactory.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using System.Reflection;
 using Xsd2Code.Library.Extensions;
 using Xsd2Code.Library.Helpers;
-using System.Reflection;
 using Xsd2Code.Library.Properties;
 
 namespace Xsd2Code.Library
@@ -55,17 +53,16 @@ namespace Xsd2Code.Library
                 }
                 catch (Exception ex)
                 {
-                    return new Result<ICodeExtension>(null, false, ex.Message, MessageType.Error);
+                    return new Result<ICodeExtension>(null, false, MessageType.Error, ex.Message);
                 }
             }
 
-            return new Result<ICodeExtension>(null, false,
+            return new Result<ICodeExtension>(null, false, MessageType.Error,
                                               string.Format(Resources.UnsupportedTargetFramework,
-                                                            generatorParams.TargetFramework),
-                                              MessageType.Error);
+                                                            generatorParams.TargetFramework));
         }
 
-        internal static  ICodeExtension GetExtention(TargetFramework target)
+        internal static ICodeExtension GetExtention(TargetFramework target)
         {
             switch (target)
             {

--- a/Xsd2Code.Library/GeneratorParams.cs
+++ b/Xsd2Code.Library/GeneratorParams.cs
@@ -383,8 +383,6 @@ namespace Xsd2Code.Library
             this.TrackingChanges.PropertyChanged += TrackingChangesPropertyChanged;
             this.Serialization.DefaultEncoder = DefaultEncoder.UTF8;
             this.GenerateSeparateFiles = false;
-            this.OtherOutputFilesPaths = new List<string>();
-
         }
 
         /// <summary>
@@ -431,14 +429,6 @@ namespace Xsd2Code.Library
         /// <value>The input file path.</value>
         [Browsable(false)]
         public string InputFilePath { get; set; }
-
-        /// <summary>
-        /// Gets the output other files paths (included or imported).
-        /// </summary>
-        /// <value>The output file path.</value>
-        [Browsable(false)]
-        public List<string> OtherOutputFilesPaths { get; }
-
 
         /// <summary>
         /// Gets or sets collection type to use for code generation

--- a/Xsd2Code.Library/GeneratorParams.cs
+++ b/Xsd2Code.Library/GeneratorParams.cs
@@ -336,12 +336,12 @@ namespace Xsd2Code.Library
         private GenericBaseClassParams genericBaseClassField;
 
         /// <summary>
-        /// Indicate if use tracking change algrithm.
+        /// Indicate if use tracking change algorithm.
         /// </summary>
         private TrackingChangesParams trackingChangesField;
 
         /// <summary>
-        /// Serilisation params
+        /// Serialisation params
         /// </summary>
         private SerializeParams serializeFiledField;
 
@@ -359,13 +359,13 @@ namespace Xsd2Code.Library
         /// Indicate if implement INotifyPropertyChanged
         /// </summary>
         private PropertyParams propertyParamsField;
-        #endregion
 
         /// <summary>
         /// Indicate the target framework
         /// </summary>
         private TargetFramework targetFrameworkField = default(TargetFramework);
 
+        #endregion
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GeneratorParams"/> class.
@@ -382,6 +382,9 @@ namespace Xsd2Code.Library
             this.Miscellaneous.ExcludeIncludedTypes = false;
             this.TrackingChanges.PropertyChanged += TrackingChangesPropertyChanged;
             this.Serialization.DefaultEncoder = DefaultEncoder.UTF8;
+            this.GenerateSeparateFiles = false;
+            this.OtherOutputFilesPaths = new List<string>();
+
         }
 
         /// <summary>
@@ -428,6 +431,14 @@ namespace Xsd2Code.Library
         /// <value>The input file path.</value>
         [Browsable(false)]
         public string InputFilePath { get; set; }
+
+        /// <summary>
+        /// Gets the output other files paths (included or imported).
+        /// </summary>
+        /// <value>The output file path.</value>
+        [Browsable(false)]
+        public List<string> OtherOutputFilesPaths { get; }
+
 
         /// <summary>
         /// Gets or sets collection type to use for code generation
@@ -655,6 +666,17 @@ namespace Xsd2Code.Library
         [DefaultValue(true)]
         [Description("Enable/Disable Global initialization of the fields in both Constructors, Lazy Properties. Maximum override")]
         public bool EnableInitializeFields { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to generate the code in one file or one file per type
+        /// </summary>
+        [Category("Code")]
+        [DefaultValue(false)]
+        [Description("Generated in separate files")]
+        public bool GenerateSeparateFiles
+        {
+            get; set;
+        }
 
         /// <summary>
         /// Loads from file.

--- a/Xsd2Code.Library/Helpers/Result.cs
+++ b/Xsd2Code.Library/Helpers/Result.cs
@@ -20,7 +20,7 @@ namespace Xsd2Code.Library.Helpers
         /// Result class constructor
         /// </summary>
         public Result() : this(false)
-        {}
+        { }
 
         /// <summary>
         /// Result class constructor
@@ -78,7 +78,7 @@ namespace Xsd2Code.Library.Helpers
         {
             get
             {
-                if (this.messages == null) 
+                if (this.messages == null)
                     this.messages = new MessageCollection();
                 return this.messages;
             }
@@ -105,7 +105,7 @@ namespace Xsd2Code.Library.Helpers
         /// Default constructor
         ///</summary>
         public Result()
-        {}
+        { }
 
         /// <summary>
         /// Result class constructor
@@ -114,7 +114,7 @@ namespace Xsd2Code.Library.Helpers
         /// <param name="success">parameter value</param>
         public Result(TEntity entity, bool success)
             : this(entity, success, null)
-        {}
+        { }
 
         /// <summary>
         /// Result class constructor
@@ -135,7 +135,7 @@ namespace Xsd2Code.Library.Helpers
         /// <param name="success">parameter value</param>
         /// <param name="message">parameter value</param>
         /// <param name="MessageType">parameter value</param>
-        public Result(TEntity entity, bool success, string message, MessageType MessageType)
+        public Result(TEntity entity, bool success, MessageType MessageType, string message)
             : this(entity, success)
         {
             var messageItem = new Message(MessageType, message);

--- a/Xsd2Code.TestUnit/Properties/Resources.Designer.cs
+++ b/Xsd2Code.TestUnit/Properties/Resources.Designer.cs
@@ -72,11 +72,29 @@ namespace Xsd2Code.TestUnit.Properties {
         ///    &lt;/xs:annotation&gt;
         ///    &lt;xs:complexType&gt;
         ///      &lt;xs:sequence&gt;
-        ///        &lt;xs:element name=&quot;f [rest of string was truncated]&quot;;.
+        ///        &lt;xs:element name=&quot;n [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string Actor {
             get {
                 return ResourceManager.GetString("Actor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; ?&gt;
+        ///&lt;xs:schema xmlns:mstns=&quot;http://tempuri.org/Gender.xsd&quot; attributeFormDefault=&quot;unqualified&quot; elementFormDefault=&quot;qualified&quot; id=&quot;TVShow&quot; xmlns:xs=&quot;http://www.w3.org/2001/XMLSchema&quot;&gt;
+        ///  &lt;xs:include schemaLocation=&quot;Actor.xsd&quot; /&gt;
+        ///  &lt;xs:import schemaLocation=&quot;Gender.xsd&quot; namespace=&quot;http://tempuri.org/Gender.xsd&quot;/&gt;
+        ///
+        ///  &lt;xs:complexType name=&quot;TVShow&quot;&gt;
+        ///    &lt;xs:sequence&gt;
+        ///
+        ///      &lt;xs:element name=&quot;Title&quot; type=&quot;xs:string&quot; default=&quot;DefaultTitle&quot; nillable=&quot;true&quot;&gt;
+        ///        &lt;xs:ann [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string AnimatedShow {
+            get {
+                return ResourceManager.GetString("AnimatedShow", resourceCulture);
             }
         }
         
@@ -317,6 +335,24 @@ namespace Xsd2Code.TestUnit.Properties {
         internal static string TestAnnotations {
             get {
                 return ResourceManager.GetString("TestAnnotations", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; ?&gt;
+        ///&lt;xs:schema xmlns:mstns=&quot;http://tempuri.org/Gender.xsd&quot; attributeFormDefault=&quot;unqualified&quot; elementFormDefault=&quot;qualified&quot; id=&quot;TVShow&quot; xmlns:xs=&quot;http://www.w3.org/2001/XMLSchema&quot;&gt;
+        ///  &lt;xs:include schemaLocation=&quot;Actor.xsd&quot; /&gt;
+        ///  &lt;xs:import schemaLocation=&quot;Gender.xsd&quot; namespace=&quot;http://tempuri.org/Gender.xsd&quot;/&gt;
+        ///  
+        ///   &lt;xs:complexType name=&quot;TVShow&quot;&gt;
+        ///      &lt;xs:sequence&gt;
+        ///        
+        ///        &lt;xs:element name=&quot;Title&quot; type=&quot;xs:string&quot; default=&quot;DefaultTitle&quot; nillable=&quot;true&quot;&gt;
+        /// [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TVShow {
+            get {
+                return ResourceManager.GetString("TVShow", resourceCulture);
             }
         }
     }

--- a/Xsd2Code.TestUnit/Properties/Resources.resx
+++ b/Xsd2Code.TestUnit/Properties/Resources.resx
@@ -163,4 +163,10 @@
   <data name="nillables" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\xsd\nillables.xsd;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
+  <data name="TVShow" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\xsd\tvshow.xsd;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="AnimatedShow" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\xsd\animatedshow.xsd;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
 </root>

--- a/Xsd2Code.TestUnit/UnitTest.cs
+++ b/Xsd2Code.TestUnit/UnitTest.cs
@@ -856,7 +856,7 @@ namespace Xsd2Code.TestUnit
         }
 
         [TestMethod]
-        public void Includes()
+        public void MultipleGenerationWithSeparateFiles()
         {
             lock (testLock)
             {

--- a/Xsd2Code.TestUnit/UnitTest.cs
+++ b/Xsd2Code.TestUnit/UnitTest.cs
@@ -1,14 +1,14 @@
+using Microsoft.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Xsd2Code.Library;
 using Xsd2Code.Library.Helpers;
 using Xsd2Code.TestUnit.Properties;
-using Microsoft.CSharp;
-using System.CodeDom.Compiler;
-using System.Collections.Generic;
 using System.Reflection;
 
 namespace Xsd2Code.TestUnit
@@ -98,12 +98,12 @@ namespace Xsd2Code.TestUnit
                 // Copy resource file to the run-time directory
                 string inputFilePath = GetInputFilePath("CircularClassReference.xsd", Resources.CircularClassReference);
                 var generatorParams = new GeneratorParams
-                                          {
-                                              InputFilePath = inputFilePath,
-                                              TargetFramework = TargetFramework.Net20,
-                                              OutputFilePath = GetOutputFilePath(inputFilePath)
+                {
+                    InputFilePath = inputFilePath,
+                    TargetFramework = TargetFramework.Net20,
+                    OutputFilePath = GetOutputFilePath(inputFilePath)
 
-                                          };
+                };
                 generatorParams.PropertyParams.AutomaticProperties = true;
                 generatorParams.Serialization.Enabled = false;
                 generatorParams.GenericBaseClass.Enabled = false;
@@ -144,15 +144,15 @@ namespace Xsd2Code.TestUnit
                 var inputFilePath = GetInputFilePath("ArrayOfArray.xsd", Resources.ArrayOfArray);
 
                 var generatorParams = new GeneratorParams
-                                          {
-                                              GenerateCloneMethod = true,
-                                              InputFilePath = inputFilePath,
-                                              NameSpace = "MyNameSpace",
-                                              CollectionObjectType = CollectionType.Array,
-                                              EnableDataBinding = true,
-                                              Language = GenerationLanguage.CSharp,
-                                              OutputFilePath = Path.ChangeExtension(inputFilePath, ".TestGenerated.cs")
-                                          };
+                {
+                    GenerateCloneMethod = true,
+                    InputFilePath = inputFilePath,
+                    NameSpace = "MyNameSpace",
+                    CollectionObjectType = CollectionType.Array,
+                    EnableDataBinding = true,
+                    Language = GenerationLanguage.CSharp,
+                    OutputFilePath = Path.ChangeExtension(inputFilePath, ".TestGenerated.cs")
+                };
                 generatorParams.PropertyParams.AutomaticProperties = true;
                 generatorParams.Serialization.Enabled = true;
                 var xsdGen = new GeneratorFacade(generatorParams);
@@ -432,12 +432,12 @@ namespace Xsd2Code.TestUnit
                 Assert.IsTrue(result.Success, result.Messages.ToString());
 
                 var genderRoot = new Root
-                                     {
-                                         GenderAttribute = ksgender.female,
-                                         GenderAttributeSpecified = true,
-                                         GenderElement = ksgender.female,
-                                         GenderIntAttribute = "toto"
-                                     };
+                {
+                    GenderAttribute = ksgender.female,
+                    GenderAttributeSpecified = true,
+                    GenderElement = ksgender.female,
+                    GenderIntAttribute = "toto"
+                };
                 Exception ex;
                 genderRoot.SaveToFile(Path.Combine(OutputFolder, "gender.xml"), out ex);
                 if (ex != null) throw ex;
@@ -480,7 +480,7 @@ namespace Xsd2Code.TestUnit
         /// Allows the debug.
         /// </summary>
         [TestMethod]
-        public void AlowDebug()
+        public void AllowDebug()
         {
             lock (testLock)
             {
@@ -657,13 +657,13 @@ namespace Xsd2Code.TestUnit
 
                 string outputFilePath = Path.ChangeExtension(inputFilePath, ".baseClass.cs");
                 var generatorParams = new GeneratorParams
-                                          {
-                                              InputFilePath = inputFilePath,
-                                              TargetFramework = TargetFramework.Net30,
-                                              GenerateDataContracts = true,
-                                              EnableDataBinding = true,
-                                              OutputFilePath = outputFilePath
-                                          };
+                {
+                    InputFilePath = inputFilePath,
+                    TargetFramework = TargetFramework.Net30,
+                    GenerateDataContracts = true,
+                    EnableDataBinding = true,
+                    OutputFilePath = outputFilePath
+                };
 
                 generatorParams.PropertyParams.AutomaticProperties = false;
                 generatorParams.Miscellaneous.EnableSummaryComment = true;
@@ -822,6 +822,103 @@ namespace Xsd2Code.TestUnit
             }
         }
 
+        [TestMethod]
+        public void SeparateFiles()
+        {
+            lock (testLock)
+            {
+
+                // Get the code namespace for the schema.
+                string tvShowInputFilePath = GetInputFilePath("TVShow.xsd", Resources.TVShow);
+                // copy included/imported files to the test folder
+                GetInputFilePath("Actor.xsd", Resources.Actor);
+                GetInputFilePath("Gender.xsd", Resources.Gender);
+
+                var tvShowGeneratorParams = GetGeneratorParams(tvShowInputFilePath);
+                GetGeneratorParams(tvShowInputFilePath);
+
+                tvShowGeneratorParams.Miscellaneous.EnableSummaryComment = true;
+                tvShowGeneratorParams.TargetFramework = TargetFramework.Net35;
+                tvShowGeneratorParams.PropertyParams.AutomaticProperties = true;
+                tvShowGeneratorParams.EnableInitializeFields = true;
+                tvShowGeneratorParams.CollectionObjectType = CollectionType.List;
+                tvShowGeneratorParams.GenerateSeparateFiles = true;
+                tvShowGeneratorParams.OutputFilePath = Path.ChangeExtension(tvShowGeneratorParams.InputFilePath, ".separate.cs");
+
+                var tvShowXsdGen = new GeneratorFacade(tvShowGeneratorParams);
+                var tvShowResult = tvShowXsdGen.Generate();
+                List<string> tvShowOutputFiles = tvShowResult.Entity;
+                Assert.IsTrue(tvShowResult.Success, tvShowResult.Messages.ToString());
+                // compile TV show
+                var compileResult = CompileCSFile(tvShowOutputFiles.ToArray());
+                Assert.IsTrue(compileResult.Success, compileResult.Messages.ToString());
+            }
+        }
+
+        [TestMethod]
+        public void Includes()
+        {
+            lock (testLock)
+            {
+
+                // Get the code namespace for the schema.
+                string tvShowInputFilePath = GetInputFilePath("TVShow.xsd", Resources.TVShow);
+                // copy included/imported files to the test folder
+                GetInputFilePath("Actor.xsd", Resources.Actor);
+                GetInputFilePath("Gender.xsd", Resources.Gender);
+
+                var tvShowGeneratorParams = GetGeneratorParams(tvShowInputFilePath);
+                GetGeneratorParams(tvShowInputFilePath);
+
+                tvShowGeneratorParams.Miscellaneous.EnableSummaryComment = true;
+                tvShowGeneratorParams.TargetFramework = TargetFramework.Net35;
+                tvShowGeneratorParams.PropertyParams.AutomaticProperties = true;
+                tvShowGeneratorParams.EnableInitializeFields = true;
+                tvShowGeneratorParams.GenerateSeparateFiles = true;
+                tvShowGeneratorParams.CollectionObjectType = CollectionType.List;
+                tvShowGeneratorParams.OutputFilePath = Path.Combine(Path.GetDirectoryName(tvShowInputFilePath), "includes.cs");
+
+                var tvShowXsdGen = new GeneratorFacade(tvShowGeneratorParams);
+                var tvShowResult = tvShowXsdGen.Generate();
+                List<string> tvShowOutputFiles = tvShowResult.Entity;
+                Assert.IsTrue(tvShowResult.Success, tvShowResult.Messages.ToString());
+
+                // Get the code namespace for the schema.
+                string inputFilePath = GetInputFilePath("AnimatedShow.xsd", Resources.AnimatedShow);
+
+                var animatedShowGeneratorParams = GetGeneratorParams(inputFilePath);
+                GetGeneratorParams(inputFilePath);
+
+                animatedShowGeneratorParams.Miscellaneous.EnableSummaryComment = true;
+                animatedShowGeneratorParams.TargetFramework = TargetFramework.Net35;
+                animatedShowGeneratorParams.PropertyParams.AutomaticProperties = true;
+                animatedShowGeneratorParams.EnableInitializeFields = true;
+                animatedShowGeneratorParams.GenerateSeparateFiles = true;
+                animatedShowGeneratorParams.CollectionObjectType = CollectionType.List;
+                // using the same base file name to check if multiple generations with common imports/includes can successfully compile
+                animatedShowGeneratorParams.OutputFilePath = Path.Combine(Path.GetDirectoryName(tvShowInputFilePath), "includes.cs");
+
+                var animatedShowXsdGen = new GeneratorFacade(animatedShowGeneratorParams);
+                var animatedShowResult = animatedShowXsdGen.Generate();
+                List<string> animatedShowOutputFiles = animatedShowResult.Entity;
+                Assert.IsTrue(animatedShowResult.Success, animatedShowResult.Messages.ToString());
+
+                // compile TV show
+                var compileResult = CompileCSFile(tvShowOutputFiles.ToArray());
+                Assert.IsTrue(compileResult.Success, compileResult.Messages.ToString());
+                // compile Animated show
+                compileResult = CompileCSFile(animatedShowOutputFiles.ToArray());
+                Assert.IsTrue(compileResult.Success, compileResult.Messages.ToString());
+
+                // compile Animated show and tv show at the same time
+                List<string> filesToCompile = new List<string>();
+                filesToCompile.AddRange(tvShowOutputFiles.ToArray());
+                filesToCompile.AddRange(animatedShowOutputFiles.ToArray());
+                compileResult = CompileCSFile(filesToCompile.ToArray());
+                Assert.IsTrue(compileResult.Success, compileResult.Messages.ToString());
+            }
+        }
+
 
         private static string GetInputFilePath(string resourceFileName, string fileContent)
         {
@@ -844,16 +941,16 @@ namespace Xsd2Code.TestUnit
         private static GeneratorParams GetGeneratorParams(string inputFilePath)
         {
             var generatorParams = new GeneratorParams
-                       {
-                           InputFilePath = inputFilePath,
-                           NameSpace = CodeGenerationNamespace,
-                           TargetFramework = TargetFramework.Net20,
-                           CollectionObjectType = CollectionType.ObservableCollection,
-                           EnableDataBinding = true,
-                           GenerateDataContracts = true,
-                           GenerateCloneMethod = true,
-                           OutputFilePath = GetOutputFilePath(inputFilePath)
-                       };
+            {
+                InputFilePath = inputFilePath,
+                NameSpace = CodeGenerationNamespace,
+                TargetFramework = TargetFramework.Net20,
+                CollectionObjectType = CollectionType.ObservableCollection,
+                EnableDataBinding = true,
+                GenerateDataContracts = true,
+                GenerateCloneMethod = true,
+                OutputFilePath = GetOutputFilePath(inputFilePath)
+            };
             generatorParams.Miscellaneous.HidePrivateFieldInIde = true;
             generatorParams.Miscellaneous.DisableDebug = true;
             generatorParams.Serialization.Enabled = true;
@@ -865,7 +962,7 @@ namespace Xsd2Code.TestUnit
         /// </summary>
         /// <param name="inputFilePath">input file path</param>
         /// <returns></returns>
-        static private string GetOutputFilePath(string inputFilePath)
+        private static string GetOutputFilePath(string inputFilePath)
         {
             return Path.ChangeExtension(inputFilePath, ".TestGenerated.cs");
         }
@@ -875,26 +972,33 @@ namespace Xsd2Code.TestUnit
         /// </summary>
         /// <param name="filePath">CS file path</param>
         /// <returns></returns>
-        static private Result<string> CompileCSFile(string filePath)
+        private static Result<string> CompileCSFile(params string[] filesPaths)
         {
             var result = new Result<string>(null, true);
-            var file = new FileInfo(filePath);
-            if (!file.Exists)
+            string firstFileName = null;
+            foreach (string filePath in filesPaths)
             {
-                result.Success = false;
-                result.Messages.Add(MessageType.Error, "Input file \"{0}\" does not exist", filePath);
+                var file = new FileInfo(filePath);
+                if (!file.Exists)
+                {
+                    result.Success = false;
+                    result.Messages.Add(MessageType.Error, "Input file \"{0}\" does not exist", filePath);
+                    break;
+                }
+                if (firstFileName == null)
+                    firstFileName = file.FullName;
             }
             if (result.Success)
             {
                 try
                 {
 
-                    var outputPath = Path.ChangeExtension(file.FullName, ".dll");
+                    var outputPath = Path.ChangeExtension(firstFileName, ".dll");
                     result.Entity = outputPath;
                     var csc = new CSharpCodeProvider(new Dictionary<string, string>() { { "CompilerVersion", "v3.5" } });
                     var parameters = new CompilerParameters(new[] { "mscorlib.dll", "System.dll", "System.Core.dll", "System.Xml.dll", "WindowsBase.dll", "System.Runtime.Serialization.dll" }, outputPath, true);
                     parameters.GenerateExecutable = false;
-                    CompilerResults results = csc.CompileAssemblyFromFile(parameters, filePath);
+                    CompilerResults results = csc.CompileAssemblyFromFile(parameters, filesPaths);
                     if (results.Errors.HasErrors)
                     {
                         result.Success = false;

--- a/Xsd2Code.TestUnit/Xsd2Code.TestUnit.csproj
+++ b/Xsd2Code.TestUnit/Xsd2Code.TestUnit.csproj
@@ -80,6 +80,7 @@
     <Compile Include="xsd\dvd.designer.cs" />
     <Compile Include="xsd\Gender.cs">
       <DependentUpon>Gender.xsd</DependentUpon>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Compile>
     <Compile Include="xsd\hexBinary.designer.cs" />
     <Compile Include="xsd\Hierarchical.cs">
@@ -110,12 +111,20 @@
       <SubType>
       </SubType>
     </Content>
-    <Content Include="xsd\Actor.xsd" />
+    <Content Include="xsd\Actor.xsd">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="xsd\Circular.xsd" />
+    <None Include="xsd\AnimatedShow.xsd">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="xsd\dvd.xsx">
       <DependentUpon>dvd.xsd</DependentUpon>
     </None>
-    <Content Include="xsd\Gender.xsd" />
+    <Content Include="xsd\Gender.xsd">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="xsd\Hierarchical.xsd" />
     <Content Include="xsd\ReproSchema.xsd" />
     <Content Include="xsd\StackOverFlow.xsd" />
@@ -143,6 +152,10 @@
     </None>
     <None Include="xsd\TestOptionalElement.xsd">
       <SubType>Designer</SubType>
+    </None>
+    <None Include="xsd\TVShow.xsd">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="xsd\XMLSchema.xsd">
       <SubType>Designer</SubType>

--- a/Xsd2Code.TestUnit/xsd/Actor.xsd
+++ b/Xsd2Code.TestUnit/xsd/Actor.xsd
@@ -1,6 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<!--Created with Liquid XML Studio (http://www.liquid-technologies.com)-->
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" id="Actor" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns="http://tempuri.org/Movies"
+           targetNamespace="http://tempuri.org/Movies"
+           xmlns:mstns="http://tempuri.org/Gender.xsd"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:import schemaLocation="Gender.xsd" namespace="http://tempuri.org/Gender.xsd"/>
+
+  <xs:complexType name="NameType">
+    <xs:sequence>
+      <xs:element name="firstname" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Gets or sets the firstname of the actor
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="lastname" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Gets or sets the lastname of the actor
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
   <xs:element name="Actor">
     <xs:annotation>
       <xs:documentation>
@@ -9,17 +33,11 @@
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="firstname" type="xs:string">
+        <xs:element name="name" type="NameType"/>
+        <xs:element ref="mstns:Root">
           <xs:annotation>
             <xs:documentation>
-              Gets or sets the firstname of the actor
-            </xs:documentation>
-          </xs:annotation>
-        </xs:element>
-        <xs:element name="lastname" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>
-              Gets or sets the lastname of the actor
+              Represent the gender of the main character
             </xs:documentation>
           </xs:annotation>
         </xs:element>
@@ -32,4 +50,5 @@
       </xs:attribute>
     </xs:complexType>
   </xs:element>
+
 </xs:schema>

--- a/Xsd2Code.TestUnit/xsd/AnimatedShow.xsd
+++ b/Xsd2Code.TestUnit/xsd/AnimatedShow.xsd
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<xs:schema xmlns="http://tempuri.org/Movies"
+  targetNamespace="http://tempuri.org/Movies"
+  xmlns:mstns="http://tempuri.org/Gender.xsd"
+  attributeFormDefault="unqualified"
+  elementFormDefault="qualified"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:include schemaLocation="Actor.xsd" />
+  <xs:import schemaLocation="Gender.xsd" namespace="http://tempuri.org/Gender.xsd"/>
+
+  <xs:complexType name="AnimatedShow">
+    <xs:sequence>
+
+      <xs:element name="Title" type="xs:string" default="DefaultTitle" nillable="true">
+        <xs:annotation>
+          <xs:documentation>
+            Gets or sets the title of the animated show.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element ref="Actor"  maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            Represent the actor list
+            The list include Firstname and last name of the actor.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="TargetAudienceGender" type="mstns:ksgender"  maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            Represent the targeted audience gender
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element ref="mstns:Root">
+        <xs:annotation>
+          <xs:documentation>
+            Represent the gender of the main character
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Characters" type="NameType" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            Represent the list of main characters
+            The list include Firstname and last name of the characters.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>

--- a/Xsd2Code.TestUnit/xsd/Gender.xsd
+++ b/Xsd2Code.TestUnit/xsd/Gender.xsd
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<!--Created with Liquid XML Studio - FREE Community Edition (http://www.liquid-technologies.com)-->
-<xs:schema xmlns:mstns="http://tempuri.org/Gender.xsd" elementFormDefault="qualified" targetNamespace="http://tempuri.org/Gender.xsd" id="Gender" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:mstns="http://tempuri.org/Gender.xsd"
+           targetNamespace="http://tempuri.org/Gender.xsd"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
   <xs:element name="Root">
     <xs:complexType>
       <xs:sequence>
@@ -16,4 +18,5 @@
       <xs:enumeration value="female" />
     </xs:restriction>
   </xs:simpleType>
+
 </xs:schema>

--- a/Xsd2Code.TestUnit/xsd/TVShow.xsd
+++ b/Xsd2Code.TestUnit/xsd/TVShow.xsd
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<xs:schema xmlns="http://tempuri.org/Movies"
+           targetNamespace="http://tempuri.org/Movies"
+           xmlns:mstns="http://tempuri.org/Gender.xsd"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:include schemaLocation="Actor.xsd" />
+  <xs:import schemaLocation="Gender.xsd" namespace="http://tempuri.org/Gender.xsd"/>
+
+  <xs:complexType name="TVShow">
+    <xs:sequence>
+      <xs:element name="Title" type="xs:string" default="DefaultTitle" nillable="true">
+        <xs:annotation>
+          <xs:documentation>
+            Gets or sets the title of tv show.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element ref="Actor"  maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            Represent the actor list
+            The list include Firstname and last name of the actor.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="TargetAudienceGender" type="mstns:ksgender"  maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            Represent the targeted audience gender
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element ref="mstns:Root">
+        <xs:annotation>
+          <xs:documentation>
+            Represent the gender of the main character
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="MainActorsNames" type="NameType" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            Represent the list of main actors
+            The list include Firstname and last name of the actor.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>

--- a/Xsd2Code.TestUnit/xsd/dvd.xsd
+++ b/Xsd2Code.TestUnit/xsd/dvd.xsd
@@ -1,6 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <!--Created with Liquid XML Studio Designer Edition (http://www.liquid-technologies.com)-->
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" id="Dvd" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns="http://tempuri.org/Movies"
+           targetNamespace="http://tempuri.org/Movies"
+           attributeFormDefault="unqualified"
+           elementFormDefault="qualified"
+            id="Dvd"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:include schemaLocation="Actor.xsd" />
   <xs:element name="DvdCollection">
     <xs:complexType>
@@ -23,17 +28,17 @@
       <xs:element name="Title" type="xs:string" default="DefaultTitle" nillable="true">
         <xs:annotation>
           <xs:documentation>
-              Gets or sets the title of dvd.
-            </xs:documentation>
+            Gets or sets the title of dvd.
+          </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="Style" type="Styles" default="Action" />
       <xs:element ref="Actor" maxOccurs="unbounded">
         <xs:annotation>
           <xs:documentation>
-              Represent the actor list
-              The list include Firstname and last name of the actor.
-            </xs:documentation>
+            Represent the actor list
+            The list include Firstname and last name of the actor.
+          </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="PublishYear" type="xs:int" />

--- a/Xsd2Code.vsPackage/GenerateCodeFromXSDCommand.cs
+++ b/Xsd2Code.vsPackage/GenerateCodeFromXSDCommand.cs
@@ -5,6 +5,7 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Globalization;
 using Microsoft.VisualStudio.Shell;
@@ -189,8 +190,8 @@ namespace Xsd2Code.vsPackage
             {
                 if (result == DialogResult.OK)
                 {
-                    Result<string> generateResult = gen.Generate();
-                    string outputFileName = generateResult.Entity;
+                    Result<List<string>> generateResult = gen.Generate();
+                    List<string> outputFileNames = generateResult.Entity;
 
                     if (!generateResult.Success)
                         MessageBox.Show(generateResult.Messages.ToString(), "XSD2Code", MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -198,7 +199,7 @@ namespace Xsd2Code.vsPackage
                     {
                         if (!found)
                         {
-                            projElmts = proitem.Collection.AddFromFile(outputFileName);
+                            projElmts = proitem.Collection.AddFromFile(gen.GeneratorParams.OutputFilePath);
                         }
 
                         if (frm.OpenAfterGeneration)

--- a/Xsd2Code.vsPackage/Properties/AssemblyInfo.cs
+++ b/Xsd2Code.vsPackage/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyFileVersion("1.0.2.0")]
+[assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyFileVersion("1.0.3.0")]

--- a/Xsd2Code.vsPackage/Xsd2Code.vsPackage.csproj
+++ b/Xsd2Code.vsPackage/Xsd2Code.vsPackage.csproj
@@ -1,13 +1,33 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.14.1.24720\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.14.1.24720\build\Microsoft.VSSDK.BuildTools.props')" />
+  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <UseCodebase>true</UseCodebase>
     <TargetFrameworkProfile />
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>14.0</OldToolsVersion>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -193,16 +213,23 @@
       <ManifestResourceName>VSPackage</ManifestResourceName>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>Ce projet fait référence à des packages NuGet qui sont manquants sur cet ordinateur. Utilisez l'option de restauration des packages NuGet pour les télécharger. Pour plus d'informations, consultez http://go.microsoft.com/fwlink/?LinkID=322105. Le fichier manquant est : {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.14.1.24720\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.14.1.24720\build\Microsoft.VSSDK.BuildTools.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.14.1.24720\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.14.1.24720\build\Microsoft.VSSDK.BuildTools.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.14.1.24720\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.14.1.24720\build\Microsoft.VSSDK.BuildTools.targets')" />
+  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Xsd2Code.vsPackage/Xsd2Code.vsPackage.csproj
+++ b/Xsd2Code.vsPackage/Xsd2Code.vsPackage.csproj
@@ -224,7 +224,7 @@
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>Ce projet fait référence à des packages NuGet qui sont manquants sur cet ordinateur. Utilisez l'option de restauration des packages NuGet pour les télécharger. Pour plus d'informations, consultez http://go.microsoft.com/fwlink/?LinkID=322105. Le fichier manquant est : {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets'))" />

--- a/Xsd2Code.vsPackage/packages.config
+++ b/Xsd2Code.vsPackage/packages.config
@@ -18,5 +18,5 @@
   <package id="Microsoft.VisualStudio.Threading" version="14.1.111" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Utilities" version="14.1.24720" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net452" />
-  <package id="Microsoft.VSSDK.BuildTools" version="14.1.24720" targetFramework="net452" developmentDependency="true" />
+  <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/Xsd2Code.vsPackage/source.extension.vsixmanifest
+++ b/Xsd2Code.vsPackage/source.extension.vsixmanifest
@@ -2,33 +2,33 @@
 <PackageManifest Version="2.0.0"
                  xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011"
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="Open.Xsd2Code.22fdc475-f463-47f5-95e8-8c8990c4081c" Version="1.1.0" Language="en-US" Publisher="-----" />
-    <DisplayName>Open Xsd2Code</DisplayName>
-    <Description xml:space="preserve">Open Xsd2Code - Visual Studio Extension</Description>
-    <MoreInfo>https://github.com/kmpm/xsd2code</MoreInfo>
-    <License>LICENCE.txt</License>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP"
-                DisplayName="Microsoft .NET Framework"
-                d:Source="Manual"
-                Version="[4.5,)" />
-    <Dependency Id="Microsoft.VisualStudio.MPF.14.0"
-                DisplayName="Visual Studio MPF 14.0"
-                d:Source="Installed"
-                Version="[14.0]" />
-  </Dependencies>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage"
-           d:Source="Project"
-           d:ProjectName="%CurrentProject%"
-           Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[15.0.26109.1,16.0)" DisplayName="C# et Visual Basic" />
-  </Prerequisites>
+    <Metadata>
+        <Identity Id="Open.Xsd2Code.22fdc475-f463-47f5-95e8-8c8990c4081c" Version="1.1.0" Language="en-US" Publisher="-----" />
+        <DisplayName>Open Xsd2Code</DisplayName>
+        <Description xml:space="preserve">Open Xsd2Code - Visual Studio Extension</Description>
+        <MoreInfo>https://github.com/kmpm/xsd2code</MoreInfo>
+        <License>LICENCE.txt</License>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP"
+                    DisplayName="Microsoft .NET Framework"
+                    d:Source="Manual"
+                    Version="[4.5,)" />
+        <Dependency Id="Microsoft.VisualStudio.MPF.14.0"
+                    DisplayName="Visual Studio MPF 14.0"
+                    d:Source="Installed"
+                    Version="[14.0]" />
+    </Dependencies>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage"
+               d:Source="Project"
+               d:ProjectName="%CurrentProject%"
+               Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[15.0.26109.1,16.0)" DisplayName="C# et Visual Basic" />
+    </Prerequisites>
 </PackageManifest>

--- a/Xsd2Code.vsPackage/source.extension.vsixmanifest
+++ b/Xsd2Code.vsPackage/source.extension.vsixmanifest
@@ -3,18 +3,14 @@
                  xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011"
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="Open.Xsd2Code.22fdc475-f463-47f5-95e8-8c8990c4081c"
-              Version="1.2"
-              Language="en-US"
-              Publisher="-----" />
+    <Identity Id="Open.Xsd2Code.22fdc475-f463-47f5-95e8-8c8990c4081c" Version="1.1.0" Language="en-US" Publisher="-----" />
     <DisplayName>Open Xsd2Code</DisplayName>
     <Description xml:space="preserve">Open Xsd2Code - Visual Studio Extension</Description>
     <MoreInfo>https://github.com/kmpm/xsd2code</MoreInfo>
     <License>LICENCE.txt</License>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community"
-                        Version="[14.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP"
@@ -32,4 +28,7 @@
            d:ProjectName="%CurrentProject%"
            Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[15.0.26109.1,16.0)" DisplayName="C# et Visual Basic" />
+  </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
This PR adds an option to generate the code in separate files instead of one.
This helps for code clarity as each generated type can now have its own partial file
Also, it allows to generate code from different XSD files in the same project while having shared imports or includes